### PR TITLE
fix draftBottle bug

### DIFF
--- a/run/draftBottle.py
+++ b/run/draftBottle.py
@@ -166,15 +166,17 @@ def main(bot,logger):
 
         def selfConstrucuer(source):
             bottleConstruct=[]
-            if "text" in str(source) or "image" in str(source):
+            if "time" in str(source):
+                return json.loads(source)#对旧数据实现兼容
+            else:
                 for i in source:
                     if "text" in i:
                         bottleConstruct.append(Plain(i["text"]))
                     elif "image" in i:
                         bottleConstruct.append(Image(path=i["image"]))
                 return bottleConstruct
-            else:
-                return json.loads(source) #对旧数据实现兼容
+                 
+        
         b1.append(ForwardMessageNode(sender_id=bot.qq, sender_name="Manyana",
                                      message_chain=MessageChain(selfConstrucuer(bottle["bottle"]))))
 


### PR DESCRIPTION
### 修复了下判断函数，让漂流瓶能正确兼容旧数据

下面会解释更改原因：

- 在新版漂流瓶记录数据中，`str(bottle["bottle"])`的数据如下：
`[{'image': 'data/autoReply/imageReply/3nB$OdC.jpg'}, {'text': '好看的说'}]`
- 而在旧版漂流瓶记录数据中，`str(bottle["bottle"])`的数据如下：
`[{"type": "Source", "id": 921914471, "time": "1970-01-20T23:34:44+00:00"}, {"type": "Plain", "text": "\uff1f"}]`

> 此处仅作示例

在原判断函数` if "text" in str(source) or "image" in **str(source):`里面，作为判断字符是`text`或者`image`，
但是新旧两版数据都含有这个两个字符，也就是无论内容是什么都会被判断为**新版漂流瓶数据**
这样就会导致兼容的**判断代码**失效
而在旧版数据中有而新版数据没有的字符是`id`or`time`or`type`
那么只要对这些特殊字符做判断就可以**正确兼容**旧数据

> 若无法正确兼容旧数据，则在发送的漂流瓶中**丢失**所有发送者发出的数据和评论者发送的评论
此处不讨论指向腾讯图床的图片失效的情况
就像是这样：
![示例](https://github.com/user-attachments/assets/748d878b-6684-412f-bdb6-838407d9b356)
在修复对旧版数据的兼容后，该漂流瓶就可以被正确查询且展现了

