### PR TITLE
为抽象塔罗牌做了一个群开关

### DIFF
--- a/config/controller.yaml
+++ b/config/controller.yaml
@@ -32,7 +32,6 @@ ai绘画:
   watchPrefix: "/"          #“看看”指令的前缀
 运势&塔罗:
   lockLuck: false           #是否锁定运势等功能的结果
-  isAbstract: false          #是否启用抽象卡组
 JMComic:            #禁漫相关功能设置
   enable: True     #全局开关
   onlyTrustUser: False #打开后，仅master授权用户可用

--- a/plugins/tarot.py
+++ b/plugins/tarot.py
@@ -1,7 +1,8 @@
 # -*- coding: gbk -*-
 import os.path
 import random
-
+import yaml
+import os
 from PIL import Image
 
 tarot = [['愚者 (The Fool)',
@@ -88,6 +89,29 @@ tarot = [['愚者 (The Fool)',
           '完成; 成功; 拥有毕生的志业; 达成目标; 永续不断; 最盛期; 完美无缺; 接触异国，将获得幸运; 到达标准; 精神亢奋; 快乐的结束; 模范情侣',
           '未完成; 无法达到计划中的成就; 因准备不足而失败; 中途无法在进行; 不完全燃烧; 一时不顺利; 饱和状态; 烦恼延续; 精神松弛; 个人惯用的表现方式; 因不成熟而 使情感受挫; 合谋; 态度不够圆融',
           'The World.jpg']]
+
+
+
+
+def manage_group_status(user_id, status=None, file_path="data/gruop_abstracttarot_switch.yaml"):
+    if not os.path.exists(file_path):
+        with open(file_path, 'w') as file:
+            yaml.dump({}, file)
+    with open(file_path, 'r') as file:
+        try:
+            users_data = yaml.safe_load(file) or {}
+        except yaml.YAMLError:
+            users_data = {}
+    if status is not None:
+        users_data[user_id] = status
+        with open(file_path, 'w') as file:
+            yaml.safe_dump(users_data, file)
+        return status
+    return users_data.get(user_id, False)
+
+
+
+
 
 
 def tarotChoice(isAbstract):

--- a/run/extraParts.py
+++ b/run/extraParts.py
@@ -28,7 +28,7 @@ from plugins.newsEveryDay import news, moyu, xingzuo, sd, chaijun, danxianglii, 
 from plugins.picGet import pic, setuGet
 from plugins.setuModerate import setuModerate
 from plugins.solveSearch import solve
-from plugins.tarot import tarotChoice,genshinDraw, qianCao
+from plugins.tarot import tarotChoice,genshinDraw, qianCao,manage_group_status
 # from plugins.youtube0 import ASMR_random,get_audio,get_img
 
 def main(bot, logger):
@@ -78,7 +78,6 @@ def main(bot, logger):
     aiReplyCore = result1.get("chatGLM").get("aiReplyCore")
     colorfulCharacterList = os.listdir("data/colorfulAnimeCharacter")
     lockResult = controllerResult.get("运势&塔罗").get("lockLuck")
-    isAbstract = controllerResult.get("运势&塔罗").get("isAbstract")
     InternetMeme = controllerResult.get("图片相关").get("InternetMeme")
 
     global picData
@@ -679,7 +678,7 @@ def main(bot, logger):
                 event.message_chain) == "今日塔罗":
             logger.info("获取今日塔罗")
             if not lockResult:
-                txt, img = tarotChoice(isAbstract)
+                txt, img = tarotChoice(manage_group_status(int(event.group.id)))
                 logger.info("成功获取到今日塔罗")
                 await bot.send(event, [txt, Image(path=img)])
                 if aiReplyCore:
@@ -689,7 +688,7 @@ def main(bot, logger):
 
             else:
                 if event.sender.id not in luckList.get(tod).get("塔罗"):
-                    txt, img = tarotChoice(isAbstract)
+                    txt, img = tarotChoice(manage_group_status(int(event.group.id)))
                     logger.info("成功获取到今日塔罗")
                     await bot.send(event, txt)
                     await bot.send(event, Image(path=img))
@@ -706,6 +705,12 @@ def main(bot, logger):
                     await bot.send(event, r, True)
                 with open('data/lockLuck.yaml', 'w', encoding="utf-8") as file:
                     yaml.dump(luckList, file, allow_unicode=True)
+        if "开启抽象塔罗牌" in str(event.message_chain):
+            manage_group_status(int(event.group.id), True)
+            await bot.send(event, "已为本群开启抽象塔罗牌，请发送“今日塔罗”以开始！")
+        if "关闭抽象塔罗牌" in str(event.message_chain):
+            manage_group_status(int(event.group.id), False)
+            await bot.send(event, "已为本群关闭抽象塔罗牌")
 
     @bot.on(GroupMessage)
     async def tarotToday(event: GroupMessage):


### PR DESCRIPTION
# 为抽象塔罗牌做了一个群开关

在原有的基础上做了些修改
经过群友反应，有的人还是希望保留原来的塔罗牌
所以为每个群做了抽象塔罗的群开关功能（嗯，大概就是这样
## 新指令

- 开启抽象塔罗牌
- 关闭抽象塔罗牌

> 这些都仅仅操作对应群的开关，未使用过指令的默认原版塔罗

## 代码解释
### 函数新增

- 在`plungin`下的`tarot.py`中新增`manage_group_status`方法，用以查询每个群聊的对应状态相应数据保存在`data/gruop_abstracttarot_switch.yaml`下
- 在`run`的`extraParts.py`下，用以上方法替代原有的开关状态
